### PR TITLE
Feature favorites storage

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -23,7 +23,7 @@
 }
 
 @keyframes run {
-    0% { right: 0;}
+    0% { right: -10%;}
     100%{ right : 91%;}
     /* 100%{ left: 0;} */
 }

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -19,7 +19,7 @@
   position: absolute;
   animation: linear initial alternate;
   animation-name: run;
-  animation-duration: 3s;
+  animation-duration: 4s;
 }
 
 @keyframes run {

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -15,11 +15,13 @@
   flex-direction: row;
   position: relative;
   right: 91vw;
-  top: .5%;
+  top: .9%;
   position: absolute;
   animation: linear initial alternate;
   animation-name: run;
   animation-duration: 4s;
+  /* width: 8vw;
+  height: 11vh; */
 }
 
 @keyframes run {
@@ -37,9 +39,11 @@
 }
 
 .note-img {
-  width: 8vw;
+    width: 8vw;
   height: 11vh;
-  /* left: 1px; */
+  /* width: 3em;
+  height: 3em;
+  padding: 5px; */
 }
 
 nav {

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -19,13 +19,21 @@
   position: absolute;
   animation: linear initial alternate;
   animation-name: run;
-  animation-duration: 4s;
+  animation-duration: 3s;
 }
 
 @keyframes run {
-    0% { right: -10%;}
-    100%{ right : 91%;}
-    /* 100%{ left: 0;} */
+    0% { 
+      right: -10%;
+      opacity: 0%
+    }
+    50%{ 
+      opacity: 30%;
+    }
+    100%{ 
+      right: 91%;
+      opacity: 90%;
+    }
 }
 
 .note-img {
@@ -41,6 +49,7 @@ nav {
   align-items: center;
   margin-right: -10vw;
   z-index: 1;
+  
 }
 
 .nav-btn {
@@ -72,7 +81,8 @@ nav {
   justify-content: space-around;
   padding: 2vw 0;
   border-bottom: 2px solid white;
-  background-color: #7797F1;
+  /* background-color: #7797F1; */
+  background-image: linear-gradient(to top, #00c6fb 0%, #005bea 100%);
 }
 
 .app-name {

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -10,12 +10,37 @@
   width: auto;
 }
 
+#music-note {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  right: 91vw;
+  top: .5%;
+  position: absolute;
+  animation: linear initial alternate;
+  animation-name: run;
+  animation-duration: 4s;
+}
+
+@keyframes run {
+    0% { right: 0;}
+    100%{ right : 91%;}
+    /* 100%{ left: 0;} */
+}
+
+.note-img {
+  width: 8vw;
+  height: 11vh;
+  /* left: 1px; */
+}
+
 nav {
   width: 25%;
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-right: -10vw;
+  z-index: 1;
 }
 
 .nav-btn {
@@ -54,4 +79,5 @@ nav {
   font-size: 1.5em;
   font-style: italic;
   margin-left: -10vw;
+  z-index: 1;
 }

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -13,15 +13,13 @@
 #music-note {
   display: flex;
   flex-direction: row;
-  position: relative;
+  /* position: relative; */
   right: 91vw;
   top: .9%;
   position: absolute;
   animation: linear initial alternate;
   animation-name: run;
   animation-duration: 4s;
-  /* width: 8vw;
-  height: 11vh; */
 }
 
 @keyframes run {
@@ -39,11 +37,8 @@
 }
 
 .note-img {
-    width: 8vw;
-  height: 11vh;
-  /* width: 3em;
-  height: 3em;
-  padding: 5px; */
+  width: 4em;
+  height: 3.7em;
 }
 
 nav {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -29,11 +29,13 @@ function App() {
   const addFavorite = (id: string) => {
     type AnyType = any;
     const favorite = songResults.find((song:ISongResults) => song.id === id) as AnyType
-    if (!favoriteSongs.includes(favorite)) {
-      setFavoriteSongs([favorite, ...favoriteSongs]);
-      setState([favorite, ...favoriteSongs]);
+    if (favoriteSongs === undefined) {
+      setFavoriteSongs([favorite]);
+    } else if (!favoriteSongs.includes(favorite)) {
+      setFavoriteSongs([favorite, ...favoriteSongs])
     }
-  }
+      setState(favoriteSongs);
+    }
 
   const removeFavorite = (id: string) => {
     const favorites = favoriteSongs.filter((song:ISongResults) => song.id !== id) as any;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Form from "../Form/Form";
 import "./App.css";
 import { Route, Switch, Link } from "react-router-dom";
@@ -6,11 +6,14 @@ import { getTracksByMoodAPI } from "../../utilities/apiCalls";
 import ResultsView from "../ResultsView/ResultsView";
 import FavoritesView from '../FavoritesView/FavoritesView'
 import {ISongResults, allGenres} from '../common/Types'
+import { useLocalStorage } from '../../utilities/useLocalStorage';
+
 
 function App() {
-  const [userName, setUserName] = useState("");
+  const [userName, setUserName] = useLocalStorage("userName", '');
   const [songResults, setSongResults] = useState([]);
   const [favoriteSongs, setFavoriteSongs] = useState<ISongResults[]>([]); // type the return for setFavoriteSongs for the error: Type 'undefined' is not assignable to type 'never'.ts(2322)
+  const [state, setState] = useLocalStorage("favorites");
 
   const getMoodyTunes = async (mood: string, decade: string) => {
     const arousal: string = mood.split(",")[0];
@@ -23,24 +26,19 @@ function App() {
     setSongResults(results);
   };
 
-
-
-  const addFavorite: Function = (id: string) => {
+  const addFavorite = (id: string) => {
     type AnyType = any;
     const favorite = songResults.find((song:ISongResults) => song.id === id) as AnyType
     if (!favoriteSongs.includes(favorite)) {
-      storeFavorites(favorite);
-      setFavoriteSongs([favorite, ...favoriteSongs])
+      setFavoriteSongs([favorite, ...favoriteSongs]);
+      setState([favorite, ...favoriteSongs]);
     }
-  }
-
-  const storeFavorites = (favorite: any) => {
-    localStorage.setItem("favorites", JSON.stringify([favorite, ...favoriteSongs]));
   }
 
   const removeFavorite = (id: string) => {
     const favorites = favoriteSongs.filter((song:ISongResults) => song.id !== id) as any;
-    setFavoriteSongs(favorites);
+    setFavoriteSongs(favorites)
+    setState(favoriteSongs);
   }
 
   const checkSongResults = () => {
@@ -83,10 +81,10 @@ function App() {
       <Switch>
         <Route
           path='/favorites'
-          render={props => (<FavoritesView
+          render={props => (
+          <FavoritesView
             removeFavorite={removeFavorite}
-            favoriteSongs={favoriteSongs} {...props}
-            />)}
+          />)}
         />
         <Route
           path='/results'

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -46,7 +46,7 @@ function App() {
 
   let storedFavs: any = useLocalStorage('favorites');
   useEffect(() => {
-    storedFavs = storedFavs[0];
+    storedFavs = storedFavs[0] ? storedFavs[0] : [];
     setFavoriteSongs(storedFavs);
   }, []);
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -41,6 +41,13 @@ function App() {
     setState(favoriteSongs);
   }
 
+  let storedFavs: any = useLocalStorage('favorites');
+  useEffect(() => {
+    storedFavs = storedFavs[0];
+    setFavoriteSongs(storedFavs);
+    console.log('fs', favoriteSongs)
+  }, []);
+
   const checkSongResults = () => {
     if (!songResults) {
       return (

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -23,10 +23,19 @@ function App() {
     setSongResults(results);
   };
 
+
+
   const addFavorite: Function = (id: string) => {
     type AnyType = any;
-    const favorite = songResults.find((song:ISongResults) => song.id === id) as AnyType // favorite needs to be set to any???
-    setFavoriteSongs([favorite, ...favoriteSongs]) // putting these params inside an array (error expected 1 arg but got 2+)
+    const favorite = songResults.find((song:ISongResults) => song.id === id) as AnyType
+    if (!favoriteSongs.includes(favorite)) {
+      storeFavorites(favorite);
+      setFavoriteSongs([favorite, ...favoriteSongs])
+    }
+  }
+
+  const storeFavorites = (favorite: any) => {
+    localStorage.setItem("favorites", JSON.stringify([favorite, ...favoriteSongs]));
   }
 
   const removeFavorite = (id: string) => {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -31,11 +31,12 @@ function App() {
     const favorite = songResults.find((song:ISongResults) => song.id === id) as AnyType
     if (favoriteSongs === undefined) {
       setFavoriteSongs([favorite]);
-    } else if (!favoriteSongs.includes(favorite)) {
-      setFavoriteSongs([favorite, ...favoriteSongs])
-    }
       setState(favoriteSongs);
+    } else if (!favoriteSongs.includes(favorite)) {
+      setFavoriteSongs([favorite, ...favoriteSongs]);
+      setState([favorite, ...favoriteSongs])
     }
+  }
 
   const removeFavorite = (id: string) => {
     const favorites = favoriteSongs.filter((song:ISongResults) => song.id !== id) as any;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -13,7 +13,7 @@ function App() {
   const [userName, setUserName] = useLocalStorage("userName", '');
   const [songResults, setSongResults] = useState([]);
   const [favoriteSongs, setFavoriteSongs] = useState<ISongResults[]>([]); // type the return for setFavoriteSongs for the error: Type 'undefined' is not assignable to type 'never'.ts(2322)
-  const [state, setState] = useLocalStorage("favorites");
+  const [localStorage, setLocalStorage] = useLocalStorage("favorites");
 
   const getMoodyTunes = async (mood: string, decade: string) => {
     const arousal: string = mood.split(",")[0];
@@ -31,24 +31,23 @@ function App() {
     const favorite = songResults.find((song:ISongResults) => song.id === id) as AnyType
     if (favoriteSongs === undefined) {
       setFavoriteSongs([favorite]);
-      setState(favoriteSongs);
+      setLocalStorage(favoriteSongs);
     } else if (!favoriteSongs.includes(favorite)) {
       setFavoriteSongs([favorite, ...favoriteSongs]);
-      setState([favorite, ...favoriteSongs])
+      setLocalStorage([favorite, ...favoriteSongs])
     }
   }
 
   const removeFavorite = (id: string) => {
     const favorites = favoriteSongs.filter((song:ISongResults) => song.id !== id) as any;
-    setFavoriteSongs(favorites)
-    setState(favoriteSongs);
+    setFavoriteSongs(favorites);
+    setLocalStorage(favorites);
   }
 
   let storedFavs: any = useLocalStorage('favorites');
   useEffect(() => {
     storedFavs = storedFavs[0];
     setFavoriteSongs(storedFavs);
-    console.log('fs', favoriteSongs)
   }, []);
 
   const checkSongResults = () => {
@@ -100,7 +99,9 @@ function App() {
           render={props => (
           <FavoritesView
             removeFavorite={removeFavorite}
-          />)}
+            favoriteSongs={favoriteSongs} {...props}
+            
+            />)}
         />
         <Route
           path='/results'

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -59,7 +59,10 @@ function App() {
     } else if (!songResults.length) {
       return (
         <h2>
-          Loading your results... just a moment.<br/> Please try again.
+          <br/>
+          One moment while your song results load...
+          <br/>
+          {/* <br/> Please try again. */}
         </h2>
       )
     }
@@ -74,7 +77,7 @@ function App() {
             <div className='nav-btn'>Home</div>
           </Link>
           <Link to='/favorites' className='nav-btn-link'>
-            <div className='nav-btn'>Go to Favorites</div>
+            <div className='nav-btn'>View Favorites</div>
           </Link>
         </nav>
       </header>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -71,6 +71,9 @@ function App() {
   return (
     <div className="App">
       <header className='app-header'>
+        <div id = "music-note">
+          <img className="note-img" src = "https://static.thenounproject.com/png/493888-200.png" />
+        </div>
         <h1 className='app-name'>MoodyTunes</h1>
         <nav>
           <Link to='/' className='nav-btn-link'>

--- a/src/components/Favorite/Favorite.css
+++ b/src/components/Favorite/Favorite.css
@@ -34,7 +34,6 @@
   align-items: center;
 } 
 
-
 .title-artist {
   margin-left: .3vw;
 } 

--- a/src/components/Favorite/Favorite.css
+++ b/src/components/Favorite/Favorite.css
@@ -5,7 +5,7 @@
   height: 4vh;
   border-radius: 5px;
   border: 2px solid #282c34;
-  margin-right: 2vw;
+  margin-right: .3vw;
   font-weight: bolder;
 }
 
@@ -15,22 +15,45 @@
   border: 2px solid white;
 }
 
-.favorite {
+/* .favorite {
   border-radius: 25px;
   padding: 1vw;
   box-shadow: 0px 4px 10px 0px bisque;
-  transition: all 0.2s ease-in-out;
   margin-bottom: 1em;
   width: 70vw;
   height: 13vh;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-}
+} */
 
 .fav-details {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+} 
+
+
+.title-artist {
+  margin-left: .3vw;
+} 
+
+.title-artist h1 {
+  font-size: .8em;
+} 
+
+.favorite {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background: #FF8367;
+    padding: 15px 8px;
+    margin-top: 1em;
+    margin: auto;
+    border-radius: 20px;
+    width: 20vw;
+    height: 13vh;
+    margin-bottom: 1em;
+    box-shadow: 0px 6px 10px 0px #364259;
 }

--- a/src/components/Favorite/Favorite.css
+++ b/src/components/Favorite/Favorite.css
@@ -38,7 +38,7 @@
   margin-left: .3vw;
 } 
 
-.title-artist h1 {
+.fav-title {
   font-size: .8em;
 } 
 

--- a/src/components/Favorite/Favorite.css
+++ b/src/components/Favorite/Favorite.css
@@ -1,4 +1,3 @@
-
 .remove-fav-btn {
   color: #282c34;
   background: white;
@@ -14,18 +13,9 @@
   background: #282c34;
   border: 2px solid white;
 }
-
-/* .favorite {
-  border-radius: 25px;
-  padding: 1vw;
-  box-shadow: 0px 4px 10px 0px bisque;
-  margin-bottom: 1em;
-  width: 70vw;
-  height: 13vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-} */
+.remove-fav-btn:focus {
+  outline: none
+}
 
 .fav-details {
   display: flex;
@@ -56,3 +46,4 @@
     margin-bottom: 1em;
     box-shadow: 0px 6px 10px 0px #364259;
 }
+

--- a/src/components/Favorite/Favorite.tsx
+++ b/src/components/Favorite/Favorite.tsx
@@ -7,7 +7,9 @@ const Favorite = ({id, artist, title, releaseDate, genre, removeFavorite}: Favor
   const handleClick = () => {
     removeFavorite(id);
   }
-
+  let genreTitle = genre.split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.substring(1))
+    .join(' ');
   return (
     <article className='favorite' id={id}>
       <div className="fav-details">
@@ -24,7 +26,7 @@ const Favorite = ({id, artist, title, releaseDate, genre, removeFavorite}: Favor
           <b>Release Date:</b> {releaseDate}
         </p>
         <p>
-          <b>Genre:</b> {genre}
+          <b>Genre:</b> {genreTitle}
         </p>
       </div>
     </article>

--- a/src/components/Favorite/Favorite.tsx
+++ b/src/components/Favorite/Favorite.tsx
@@ -7,6 +7,9 @@ const Favorite = ({id, artist, title, releaseDate, genre, removeFavorite}: Favor
   const handleClick = () => {
     removeFavorite(id);
   }
+  let songTitle = title.split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.substring(1))
+    .join(' ');
   let genreTitle = genre.split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.substring(1))
     .join(' ');
@@ -14,7 +17,7 @@ const Favorite = ({id, artist, title, releaseDate, genre, removeFavorite}: Favor
     <article className='favorite' id={id}>
       <div className="fav-details">
         <div className="title-artist">
-          <h1 className="fav-title">{title}</h1>
+          <h1 className="fav-title">{songTitle}</h1>
           <h3>{artist}</h3>
         </div>
         <button onClick={() => handleClick()} className="remove-fav-btn">

--- a/src/components/Favorite/Favorite.tsx
+++ b/src/components/Favorite/Favorite.tsx
@@ -5,7 +5,6 @@ import './Favorite.css';
 const Favorite = ({id, artist, title, releaseDate, genre, removeFavorite}: FavoriteProps) => {
 
   const handleClick = () => {
-    console.log("handleclick");
     removeFavorite(id);
   }
 

--- a/src/components/Favorite/Favorite.tsx
+++ b/src/components/Favorite/Favorite.tsx
@@ -14,7 +14,7 @@ const Favorite = ({id, artist, title, releaseDate, genre, removeFavorite}: Favor
     <article className='favorite' id={id}>
       <div className="fav-details">
         <div className="title-artist">
-          <h1>{title}</h1>
+          <h1 className="fav-title">{title}</h1>
           <h3>{artist}</h3>
         </div>
         <button onClick={() => handleClick()} className="remove-fav-btn">

--- a/src/components/FavoritesView/FavoritesView.css
+++ b/src/components/FavoritesView/FavoritesView.css
@@ -1,6 +1,23 @@
-
 .favorites-view {
-  width: 80%;
+   display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.favs-container {
+  /* width: 80%;
+  display: flex;
+  flex-direction: column;
+  align-items: center; */
+
+  display: flex;
+  width: 80vw;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: end;
+}
+
+.no-favorites {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/FavoritesView/FavoritesView.css
+++ b/src/components/FavoritesView/FavoritesView.css
@@ -5,11 +5,6 @@
 }
 
 .favs-container {
-  /* width: 80%;
-  display: flex;
-  flex-direction: column;
-  align-items: center; */
-
   display: flex;
   width: 80vw;
   flex-wrap: wrap;

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import Favorite from '../Favorite/Favorite';
 import './FavoritesView.css';
+import { useLocalStorage } from '../../utilities/useLocalStorage';
+
 
 interface FavoritesViewProps {
-  favoriteSongs:
-   {
-    id: string,
-    artist_display_name: string,
-    title: string,
-    releasedate: string,
-    genre: string
-  }[];
   removeFavorite: Function;
 }
 
-const FavoritesView = ({favoriteSongs, removeFavorite}: FavoritesViewProps) => {
-  console.log(favoriteSongs)
-  const favorites = favoriteSongs.map(fav => {
+
+const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
+  let storedFavs: any = useLocalStorage('favorites');
+  storedFavs = storedFavs[0];
+  if(storedFavs) {
+  const favorites = storedFavs.map((fav: any) => {
     return (
       <Favorite
         key={`${fav.id}1`}
@@ -35,6 +32,17 @@ const FavoritesView = ({favoriteSongs, removeFavorite}: FavoritesViewProps) => {
       { favorites }
     </section>
    );
+  } else {
+      return (
+    <section className='no-favorites'>
+      <h2>Favorites View</h2>
+      <br/>
+      <p>You currently do not have any favorite songs. <br/><br/>
+      Click the '⭐️' to add a song to your Favorites.
+      </p>
+    </section>
+   );
+  }
 }
 
 export default FavoritesView;

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -16,7 +16,7 @@ interface FavoritesViewProps {
 
 
 const FavoritesView = ({favoriteSongs, removeFavorite}: FavoritesViewProps) => {
-  if (!favoriteSongs) {
+  if (!favoriteSongs || favoriteSongs.length === 0) {
       return (
     <section className='no-favorites'>
       <h2>Favorites View</h2>

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -3,11 +3,9 @@ import Favorite from '../Favorite/Favorite';
 import './FavoritesView.css';
 import { useLocalStorage } from '../../utilities/useLocalStorage';
 
-
 interface FavoritesViewProps {
   removeFavorite: Function;
 }
-
 
 const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
   let storedFavs: any = useLocalStorage('favorites');

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -10,7 +10,7 @@ interface FavoritesViewProps {
 const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
   let storedFavs: any = useLocalStorage('favorites');
   storedFavs = storedFavs[0];
-  if(storedFavs.length) {
+  if(storedFavs) {
   const favorites = storedFavs.map((fav: any) => {
     return (
       <Favorite

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -16,7 +16,7 @@ interface FavoritesViewProps {
 
 
 const FavoritesView = ({favoriteSongs, removeFavorite}: FavoritesViewProps) => {
-  if (!favoriteSongs || favoriteSongs.length === 0) {
+  if (favoriteSongs.length === 0) {
       return (
     <section className='no-favorites'>
       <h2>Favorites View</h2>

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -12,7 +12,7 @@ interface FavoritesViewProps {
 const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
   let storedFavs: any = useLocalStorage('favorites');
   storedFavs = storedFavs[0];
-  if(storedFavs) {
+  if(storedFavs.length) {
   const favorites = storedFavs.map((fav: any) => {
     return (
       <Favorite
@@ -26,10 +26,13 @@ const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
       />
     );
   });
+  
   return (
     <section className='favorites-view'>
       <h2>Favorites View</h2>
-      { favorites }
+      <article className='favs-container'>
+        { favorites }
+      </article>
     </section>
    );
   } else {

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -15,6 +15,7 @@ interface FavoritesViewProps {
 }
 
 const FavoritesView = ({favoriteSongs, removeFavorite}: FavoritesViewProps) => {
+  console.log(favoriteSongs)
   const favorites = favoriteSongs.map(fav => {
     return (
       <Favorite

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -10,7 +10,7 @@ interface FavoritesViewProps {
 const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
   let storedFavs: any = useLocalStorage('favorites');
   storedFavs = storedFavs[0];
-  if(storedFavs) {
+  if(storedFavs.length) {
   const favorites = storedFavs.map((fav: any) => {
     return (
       <Favorite

--- a/src/components/FavoritesView/FavoritesView.tsx
+++ b/src/components/FavoritesView/FavoritesView.tsx
@@ -4,14 +4,30 @@ import './FavoritesView.css';
 import { useLocalStorage } from '../../utilities/useLocalStorage';
 
 interface FavoritesViewProps {
+  favoriteSongs: {
+    id: string,
+    artist_display_name: string,
+    title: string,
+    releasedate: string,
+    genre: string
+  }[];
   removeFavorite: Function;
 }
 
-const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
-  let storedFavs: any = useLocalStorage('favorites');
-  storedFavs = storedFavs[0];
-  if(storedFavs.length) {
-  const favorites = storedFavs.map((fav: any) => {
+
+const FavoritesView = ({favoriteSongs, removeFavorite}: FavoritesViewProps) => {
+  if (!favoriteSongs) {
+      return (
+    <section className='no-favorites'>
+      <h2>Favorites View</h2>
+      <br/>
+      <p>You currently do not have any favorite songs. <br/><br/>
+      Click the '⭐️' to add a song to your Favorites.
+      </p>
+    </section>
+   );
+  } else {
+  const favorites = favoriteSongs.map((fav: any) => {
     return (
       <Favorite
         key={`${fav.id}1`}
@@ -24,7 +40,6 @@ const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
       />
     );
   });
-  
   return (
     <section className='favorites-view'>
       <h2>Favorites View</h2>
@@ -33,17 +48,7 @@ const FavoritesView = ({removeFavorite}: FavoritesViewProps) => {
       </article>
     </section>
    );
-  } else {
-      return (
-    <section className='no-favorites'>
-      <h2>Favorites View</h2>
-      <br/>
-      <p>You currently do not have any favorite songs. <br/><br/>
-      Click the '⭐️' to add a song to your Favorites.
-      </p>
-    </section>
-   );
-  }
+  } 
 }
 
 export default FavoritesView;

--- a/src/components/Form/Form.css
+++ b/src/components/Form/Form.css
@@ -18,7 +18,6 @@ form h2 {
     width: 70vw;
     border-radius: 15px;
     padding: 5px;
-    
     border: solid 2px;
 }
 
@@ -66,8 +65,6 @@ form button:hover{
   padding: 9px;
   border-radius: 15px;
 }
-
-
 
 .form-options p:hover {
   border: solid 1px orange;

--- a/src/components/Form/Form.css
+++ b/src/components/Form/Form.css
@@ -3,8 +3,13 @@ form {
   margin-top: 2vw;
 }
 
+form h2 {
+  margin-bottom: 0px;
+  margin-left: 15%;
+}
+
 .form-options {
-  margin: 0 2vw 1vh;
+  margin: 0 2vw 1vh 0vw;
     display: flex;
     align-items: baseline;
     flex-wrap: wrap;
@@ -29,20 +34,10 @@ form {
   margin: 1vh 0 1vh 0;
 }
 
-form article {
-    display: flex;
-    align-items: baseline;
-    flex-wrap: wrap;
-    flex-direction: row;
-    justify-content: space-around;
-    width: auto;
-    border-radius: 15px;
-    padding: 10px;
-    border: solid 2px;
-}
-
 button a {
-    text-decoration: none;
+  text-decoration: none;
+  color: black;
+  font-weight: bold;
 }
 
 .button-container {
@@ -53,10 +48,17 @@ button a {
 
 form button {
   height: 5vh;
+  width: 7vw;
   border-radius: 15px;
-  border: solid 2px orange;
+  border: solid 2px white;
   margin-bottom: 2em;
   text-decoration: none;
+  transition: all 0.2s ease-in-out;
+}
+
+form button:hover{
+  border: 1.5px solid orange;
+   text-decoration: none;
 }
 
 .choice {

--- a/src/components/Form/Form.css
+++ b/src/components/Form/Form.css
@@ -45,8 +45,18 @@ button a {
     text-decoration: none;
 }
 
+.button-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
 form button {
-  height: 4vh
+  height: 5vh;
+  border-radius: 15px;
+  border: solid 2px orange;
+  margin-bottom: 2em;
+  text-decoration: none;
 }
 
 .choice {

--- a/src/components/Form/Form.css
+++ b/src/components/Form/Form.css
@@ -60,6 +60,10 @@ form button:hover{
    text-decoration: none;
 }
 
+form button:focus {
+  outline: none;
+}
+
 .choice {
   border: solid 2px #282c34;
   padding: 9px;

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -10,7 +10,6 @@ const Form = ({ getMoodyTunes }: FormProps) => {
 
   const handleClick = (event: MouseEvent) => {
     event.preventDefault();
-
     getMoodyTunes(mood, decade);
   }
 
@@ -73,9 +72,12 @@ const getStylings = (selector:string, elementId:string) => {
         <p className={ getStylings(decade, 'date10') } onClick={ event => setDecade('date10')}>2010's</p><br/>
         </div>
         <br/>
-        <button onClick={ (event: React.MouseEvent<HTMLElement>) => handleClick(event as any) }>
-          <Link to='/results'>Get Songs</Link>
-        </button>
+        <div className='button-container'>
+          <button onClick={ (event: React.MouseEvent<HTMLElement>) => handleClick(event as any) }>
+            <Link to='/results'>Get Songs</Link>
+          </button>
+        </div>
+  
 
       </form>
     </div>

--- a/src/components/Result/Result.css
+++ b/src/components/Result/Result.css
@@ -37,18 +37,14 @@ h3 {
     font-size: .6em;
 }
 
-/* .song-details button {
-    width: 5vw;
-    height: 5vh;
-    background: none;
-    border: none;
-} */
-
 .favoriteBtn{
   font-size: 2vw;
   background: none;
   border: none;
+}
 
+.favoriteBtn:focus {
+    outline: none
 }
 
 .favoriteBtn:hover{

--- a/src/components/Result/Result.css
+++ b/src/components/Result/Result.css
@@ -1,5 +1,3 @@
-
-
 .container-title {
     margin: 1em;
     align-self: center;
@@ -45,11 +43,14 @@ h3 {
     background: none;
     border: none;
 } */
+
 .favoriteBtn{
   font-size: 2vw;
   background: none;
   border: none;
+
 }
+
 .favoriteBtn:hover{
   cursor: pointer;
   font-size: 2.5vw;

--- a/src/components/Result/Result.tsx
+++ b/src/components/Result/Result.tsx
@@ -5,8 +5,10 @@ const Result = ({ id, artist, title, releaseDate, genre, addFavorite}: ResultPro
   const handleClick = () => {
     addFavorite(id);
   };
-var songTitle = title;
-songTitle = title.split(' ')
+  let songTitle = title.split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.substring(1))
+    .join(' ');
+  let genreTitle = genre.split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.substring(1))
     .join(' ');
 
@@ -27,7 +29,7 @@ songTitle = title.split(' ')
           <b>Release Date:</b> {releaseDate}
         </p>
         <p>
-          <b>Genre:</b> {genre}
+          <b>Genre:</b> {genreTitle}
         </p>
       </div>
     </article>

--- a/src/components/ResultsView/ResultsView.css
+++ b/src/components/ResultsView/ResultsView.css
@@ -1,3 +1,6 @@
 .results-view {
   width: 80%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/src/utilities/useLocalStorage.tsx
+++ b/src/utilities/useLocalStorage.tsx
@@ -10,7 +10,7 @@ export const useLocalStorage = <T,>
   const [state, setState] = useState<T | undefined>(() => {
        if (!initialValue) {
         const value = localStorage.getItem(key);
-        return value ? JSON.parse(value) : console.log('poop')
+        return value ? JSON.parse(value) : console.log('no items in storage')
        }
   });
 

--- a/src/utilities/useLocalStorage.tsx
+++ b/src/utilities/useLocalStorage.tsx
@@ -12,14 +12,6 @@ export const useLocalStorage = <T,>
         const value = localStorage.getItem(key);
         return value ? JSON.parse(value) : console.log('poop')
        }
-    // if (!initialValue) return;
-    // try {
-    //   const value = localStorage.getItem(key);
-    //   return value ? JSON.parse(value) : console.log('poop')
-    // } 
-    // catch (err) {
-    //   return initialValue;
-    // }
   });
 
   useEffect(() => {
@@ -35,35 +27,3 @@ export const useLocalStorage = <T,>
   }, [state, key]);
   return [state, setState];
 };
-
-
-
-// interface IStorage {
-//   getItem(key: string): string | null;
-//   setItem(key: string, value: string): void;
-//   removeItem(key: string): void;
-// }
-
-// export default abstract class Storage<T extends string> {
-//   private readonly storage: IStorage;
-
-//   public constructor(getStorage = (): IStorage => window.localStorage) {
-//     this.storage = getStorage();
-//   }
-
-//   protected get(key: T): string | null {
-//     return this.storage.getItem(key);
-//   }
-
-//   protected set(key: T, value: string): void {
-//     this.storage.setItem(key, value);
-//   }
-
-//   protected clearItem(key: T): void {
-//     this.storage.removeItem(key);
-//   }
-
-//   protected clearItems(keys: T[]): void {
-//     keys.forEach((key) => this.clearItem(key));
-//   }
-// }

--- a/src/utilities/useLocalStorage.tsx
+++ b/src/utilities/useLocalStorage.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+
+type ReturnType<T> = [
+  T | undefined,
+  React.Dispatch<React.SetStateAction<T | undefined>>
+];
+
+export const useLocalStorage = <T,>
+(key: string, initialValue?: T): ReturnType<T> => {
+  const [state, setState] = useState<T | undefined>(() => {
+       if (!initialValue) {
+        const value = localStorage.getItem(key);
+        return value ? JSON.parse(value) : console.log('poop')
+       }
+    // if (!initialValue) return;
+    // try {
+    //   const value = localStorage.getItem(key);
+    //   return value ? JSON.parse(value) : console.log('poop')
+    // } 
+    // catch (err) {
+    //   return initialValue;
+    // }
+  });
+
+  useEffect(() => {
+    if (state) {
+      try {
+        localStorage.setItem(key, JSON.stringify(state));
+        
+      } 
+      catch (err) {
+        console.log(err);
+      }
+    }
+  }, [state, key]);
+  return [state, setState];
+};
+
+
+
+// interface IStorage {
+//   getItem(key: string): string | null;
+//   setItem(key: string, value: string): void;
+//   removeItem(key: string): void;
+// }
+
+// export default abstract class Storage<T extends string> {
+//   private readonly storage: IStorage;
+
+//   public constructor(getStorage = (): IStorage => window.localStorage) {
+//     this.storage = getStorage();
+//   }
+
+//   protected get(key: T): string | null {
+//     return this.storage.getItem(key);
+//   }
+
+//   protected set(key: T, value: string): void {
+//     this.storage.setItem(key, value);
+//   }
+
+//   protected clearItem(key: T): void {
+//     this.storage.removeItem(key);
+//   }
+
+//   protected clearItems(keys: T[]): void {
+//     keys.forEach((key) => this.clearItem(key));
+//   }
+// }


### PR DESCRIPTION
#### What does  this PR do?
- Stores favorited songs in local storage
- Adds musical note animation

#### Any background context you want to provide?
- ~~Currently, the 'View Favorites' does pull from local storage successfully & remain there on page refresh. HOWEVER, if a user refreshes the page & favorites a new song, only that song will appear in the 'View Favorites'. If we could do something like `window.onload(setFavoriteSongs(localStorage.getItem('favorites')` that would be groovy, but 1) thats not proper syntax & 2) even if it was TypeScript would probably throw a fit about it.~~
- The styling & animation are completely optional. We can get rid of it if it's too distracting or not thematic.
- I noticed that sometimes the 'Get Songs' button in the Form requires a double click. Though, on the first click one set of results are given, & then on the second click a completely new set of results are given.
